### PR TITLE
Fixed sigabrt on 32bit ubuntu 11.10

### DIFF
--- a/base64.cc
+++ b/base64.cc
@@ -135,11 +135,8 @@ base64_encode_binding(const Arguments &args)
         );
     }
     else if (args[0]->IsString()) {
-        Local<String> v8str = args[0]->ToString();
-        char * buffer = (char *) malloc(v8str->Utf8Length());
-        v8str->WriteUtf8(buffer);
-        str = base64_encode((unsigned char *)buffer, strlen(buffer));
-        free(buffer);
+        String::Utf8Value v8str (args[0]->ToString());
+        str = base64_encode((unsigned char *) *v8str, v8str.length());
     }
     else
         return VException("Argument should be a buffer or a string");


### PR DESCRIPTION
So I found a problem using this library on 32bit Ubuntu 11.10, I was getting SIGABRT while I was trying to:

```
require('base64').encode('000000000000');
```

Here is more detailed log: https://gist.github.com/1685186
GDB pointed me to this: https://gist.github.com/1685242

So I rewrited a little the code which was responsible for handling the string given from javascript.
