### PR TITLE
Use relative path when creating symlink

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -16,12 +16,12 @@
                 {
                     "action_name": "symlink",
                     "inputs": [
-                        "<@(PRODUCT_DIR)/base64.node"
+                        "build/Release/base64.node"
                     ],
                     "outputs": [
-                        "<(module_root_dir)/base64.node"
+                        "base64.node"
                     ],
-                    "action": ["ln", "-s", "<@(PRODUCT_DIR)/base64.node", "<(module_root_dir)/base64.node"]
+                    "action": ["ln", "-s", "build/Release/base64.node", "base64.node"]
                 }
             ]
         }


### PR DESCRIPTION
We package our nodejs apps for deployment. The paths of the apps are different between build server and production servers. Using relative path symlink gives us more flexibility. 

I don't know much about the binding file. I made the change at the most obvious place and it worked. If there is a better way to do it, please let me know. I will update this PR. 
